### PR TITLE
Make GetName() check lowercase column name

### DIFF
--- a/src/AdoNet.Specification.Tests/DataReaderTestBase.cs
+++ b/src/AdoNet.Specification.Tests/DataReaderTestBase.cs
@@ -217,10 +217,10 @@ namespace AdoNet.Specification.Tests
 			using (var connection = CreateOpenConnection())
 			using (var command = connection.CreateCommand())
 			{
-				command.CommandText = "SELECT 1 AS Id;";
+				command.CommandText = "SELECT 1 AS id;";
 				using (var reader = command.ExecuteReader())
 				{
-					Assert.Equal("Id", reader.GetName(0));
+					Assert.Equal("id", reader.GetName(0));
 				}
 			}
 		}


### PR DESCRIPTION
PostgreSQL folds unquoted identifiers to lowercase.